### PR TITLE
Mouse keyboard

### DIFF
--- a/host-to-device/07/28/0728.md
+++ b/host-to-device/07/28/0728.md
@@ -2,7 +2,7 @@
 
 Must be preceded by a stream of [`7f` packets](https://github.com/mattanger/ckb-next/wiki/Corsair-Protocol#7f-nn-ss-00---write-multiple-packet-stream), in the sequence of:
 
-`C` is the colour type, `N` is the number of packets (not bytes!) for this colour, `F` is a finish marker - `1` if not finished, `2` if finished.
+`C` is the colour type, `N` is the number of packets (not bytes!) for this colour, `F` is a finish marker - `1` if not finished, `2` if finished. If setting the keyboard to a single static colour, for example blue, it is not necessary to send packets for red and green (this is actually how the corsair protocol behaves) and F is set to 2; that said, sending subsequent red and green packets would result in layering regardless. Below is an example of a layered RGB colour change.
 
 - Red values per key (one byte of colour) in 3 `7f` packets.
 - `07 28 01 03 01` - `C` for red is `1`, `0N` is number of packets for this colour - `3`, `0F` is `1` - packets are not finished.

--- a/host-to-device/07/28/0728.md
+++ b/host-to-device/07/28/0728.md
@@ -1,0 +1,12 @@
+### *`07 28 0C 0N 0F`* - Submit keyboard colour change - 24 bit colour
+
+Must be preceded by a stream of [`7f` packets](https://github.com/mattanger/ckb-next/wiki/Corsair-Protocol#7f-nn-ss-00---write-multiple-packet-stream), in the sequence of:
+
+`C` is the colour type, `N` is the number of packets (not bytes!) for this colour, `F` is a finish marker - `1` if not finished, `2` if finished.
+
+- Red values per key (one byte of colour) in 3 `7f` packets.
+- `07 28 01 03 01` - `C` for red is `1`, `0N` is number of packets for this colour - `3`, `0F` is `1` - packets are not finished.
+- Green values per key (one byte of colour) in 3 `7f` packets.
+- `07 28 02 03 01` - `C` for green is `2`, `0N` is number of packets for this colour - `3`, `0F` is `1` - packets are not finished.
+- Blue values per key (one byte of colour) in 3 `7f` packets.
+- `07 28 03 03 02` - `C` for blue is `3`, `0N` is number of packets for this colour - `3`, `0F` is `2` - packet stream is finished.

--- a/host-to-device/0e/01/0e01.md
+++ b/host-to-device/0e/01/0e01.md
@@ -78,3 +78,13 @@ dc
 02
 ```
 
+Continuation from a mousepad:
+```
+c2 [??? - mousepad identification byte?]
+ff [???]
+40
+00
+00
+00
+...
+```


### PR DESCRIPTION
Add the mousepad firmware ident response and notes on 0728 when setting keyboards to a static 24-bit colour.